### PR TITLE
Improve ToLowerCamel()

### DIFF
--- a/camel.go
+++ b/camel.go
@@ -10,9 +10,13 @@ func toCamelInitCase(s string, initCase bool) string {
 	s = strings.Trim(s, " ")
 	n := ""
 	capNext := initCase
-	for _, v := range s {
+	for i, v := range s {
 		if v >= 'A' && v <= 'Z' {
-			n += string(v)
+			if !initCase && i == 0 {
+				n += strings.ToLower(string(v))
+			} else {
+				n += string(v)
+			}
 		}
 		if v >= '0' && v <= '9' {
 			n += string(v)

--- a/camel_test.go
+++ b/camel_test.go
@@ -29,6 +29,8 @@ func TestToCamel(t *testing.T) {
 func TestToLowerCamel(t *testing.T) {
 	cases := [][]string{
 		[]string{"foo-bar", "fooBar"},
+		[]string{"TestCase", "testCase"},
+		[]string{"AnyKind of_string", "anyKindOfString"},
 	}
 	for _, i := range cases {
 		in := i[0]


### PR DESCRIPTION
In the current `ToLowerCamel()`, there is an issue about string with initial letters capitalized.
```
"TestCase" -> "TestCase"
```
In this case, I guess `ToLowerCamel()` should return "testCase".

@iancoleman 
Do you have any idea about this issue?