### PR TITLE
Improve ToLowerCamel()

### DIFF
--- a/camel.go
+++ b/camel.go
@@ -38,5 +38,11 @@ func ToCamel(s string) string {
 }
 
 func ToLowerCamel(s string) string {
+	if s == "" {
+		return s
+	}
+	if r := rune(s[0]); r >= 'A' && r <= 'Z' {
+		s = strings.ToLower(string(r)) + s[1:]
+	}
 	return toCamelInitCase(s, false)
 }

--- a/camel_test.go
+++ b/camel_test.go
@@ -29,6 +29,9 @@ func TestToCamel(t *testing.T) {
 func TestToLowerCamel(t *testing.T) {
 	cases := [][]string{
 		[]string{"foo-bar", "fooBar"},
+		[]string{"TestCase", "testCase"},
+		[]string{"", ""},
+		[]string{"AnyKind of_string", "anyKindOfString"},
 	}
 	for _, i := range cases {
 		in := i[0]


### PR DESCRIPTION
In the current ToLowerCamel(), there is an issue about string with initial letters capitalized.
```
str := strcase.ToLowerCamel("TestCase") // str = "TestCase"
```
In this case, I guess ToLowerCamel() should return "testCase".

@iancoleman
Do you have any idea about this issue?