### PR TITLE
Fix error in TolowerCamel when deal with strings with ID

### DIFF
--- a/camel.go
+++ b/camel.go
@@ -68,6 +68,9 @@ func ToLowerCamel(s string) string {
 	if s == "" {
 		return s
 	}
+	if strings.Index(s, "ID") != -1 {
+		s = strings.Replace(s, "ID", "Id", -1)
+	}
 	if r := rune(s[0]); r >= 'A' && r <= 'Z' {
 		s = strings.ToLower(string(r)) + s[1:]
 	}

--- a/camel_test.go
+++ b/camel_test.go
@@ -56,6 +56,8 @@ func TestToLowerCamel(t *testing.T) {
 		{"TestCase", "testCase"},
 		{"", ""},
 		{"AnyKind of_string", "anyKindOfString"},
+		{"UserID", "userId"},
+		{"ID", "id"},
 	}
 	for _, i := range cases {
 		in := i[0]


### PR DESCRIPTION
# Description

When i was using this package to deal with field like 'UserID' and 'ID',I found it won't change the original word correctly into 'userId' and 'Id'

# Solution

User strings to check if there is 'ID' contains in the string,then replace the 'ID' with 'Id' when strings.Contains() return other than -1.