### PR TITLE
treat next letter after `.` as cap

### DIFF
--- a/camel.go
+++ b/camel.go
@@ -49,7 +49,7 @@ func toCamelInitCase(s string, initCase bool) string {
 				n += string(v)
 			}
 		}
-		if v == '_' || v == ' ' || v == '-' {
+		if v == '_' || v == ' ' || v == '-' || v == '.' {
 			capNext = true
 		} else {
 			capNext = false

--- a/camel_test.go
+++ b/camel_test.go
@@ -31,6 +31,7 @@ import (
 func TestToCamel(t *testing.T) {
 	cases := [][]string{
 		{"test_case", "TestCase"},
+		{"test.case", "TestCase"},
 		{"test", "Test"},
 		{"TestCase", "TestCase"},
 		{" test  case ", "TestCase"},
@@ -56,6 +57,7 @@ func TestToLowerCamel(t *testing.T) {
 		{"TestCase", "testCase"},
 		{"", ""},
 		{"AnyKind of_string", "anyKindOfString"},
+		{"AnyKind.of-string", "anyKindOfString"},
 	}
 	for _, i := range cases {
 		in := i[0]


### PR DESCRIPTION
Hey, Ian.
Please consider `.` as delimiter to capitalize a letter next to it.
Thanks and appreciate for the module 