### PR TITLE
Reintroduce strings.TrimCase in snake

### DIFF
--- a/snake.go
+++ b/snake.go
@@ -64,27 +64,10 @@ func ToDelimited(s string, delimiter uint8) string {
 // or delimited.snake.case
 // (in this case `delimiter = '.'; screaming = false`)
 func ToScreamingDelimited(s string, delimiter uint8, ignore uint8, screaming bool) string {
+	s = strings.TrimSpace(s)
 	n := strings.Builder{}
 	n.Grow(len(s) + 2) // nominal 2 bytes of extra space for inserted delimiters
-	start := true
-	spaces := 0
 	for i, v := range []byte(s) {
-		if v == ' ' {
-			spaces++
-			continue
-		} else if start {
-			start = false
-			spaces = 0
-		} else {
-			for ; spaces > 0; spaces-- {
-				if ignore == ' ' {
-					n.WriteByte(' ')
-				} else {
-					n.WriteByte(delimiter)
-				}
-			}
-		}
-
 		vIsCap := v >= 'A' && v <= 'Z'
 		vIsLow := v >= 'a' && v <= 'z'
 		if vIsLow && screaming {


### PR DESCRIPTION
Interesting, I was going to complain about the reintroduction of `strings.TrimSpace` in camel but decided to measure and it turns out it's ~5% faster than doing it manually!

So we're obviously in micro-optimization land here, but might as well keep it simple/consistent and trim spaces the same way in snake too.