### PR TITLE
Provides ability to configure custom acronyms

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,29 @@ s := "AnyKind of_string"
 ```bash
 go get -u github.com/iancoleman/strcase
 ```
+
+## Custom Acronyms for ToCamel && ToLowerCamel
+
+Often times text can contain specific acronyms which you need to be handled a certain way.
+Out of the box `strcase` treats the string "ID" as "Id" or "id" but there is no way to cater
+for every case in the wild.
+
+To configure your custom acronym globally you can use the following before running any conversion
+
+```go
+import (
+    "github.com/iancoleman/strcase"
+)
+
+func init() {
+    // results in "Api" using ToCamel("API")
+    // results in "api" using ToLowerCamel("API")
+    strcase.ConfigureAcronym("API", "api")
+    
+    // results in "PostgreSQL" using ToCamel("PostgreSQL")
+    // results in "postgreSQL" using ToLowerCamel("PostgreSQL")
+    strcase.ConfigureAcronym("PostgreSQL", "PostgreSQL")
+
+}
+
+```

--- a/acronyms.go
+++ b/acronyms.go
@@ -3,3 +3,8 @@ package strcase
 var uppercaseAcronym = map[string]string{
 	"ID": "id",
 }
+
+// ConfigureAcronym allows you to add additional words which will be considered acronyms
+func ConfigureAcronym(key, val string) {
+	uppercaseAcronym[key] = val
+}

--- a/camel_test.go
+++ b/camel_test.go
@@ -85,6 +85,78 @@ func TestToLowerCamel(t *testing.T) {
 	toLowerCamel(t)
 }
 
+func TestCustomAcronymsToCamel(t *testing.T) {
+	tests := []struct {
+		name         string
+		acronymKey   string
+		acronymValue string
+		expected     string
+	}{
+		{
+			name:         "API Custom Acronym",
+			acronymKey:   "API",
+			acronymValue: "api",
+			expected:     "Api",
+		},
+		{
+			name:         "ABCDACME Custom Acroynm",
+			acronymKey:   "ABCDACME",
+			acronymValue: "AbcdAcme",
+			expected:     "AbcdAcme",
+		},
+		{
+			name:         "PostgreSQL Custom Acronym",
+			acronymKey:   "PostgreSQL",
+			acronymValue: "PostgreSQL",
+			expected:     "PostgreSQL",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ConfigureAcronym(test.acronymKey, test.acronymValue)
+			if result := ToCamel(test.acronymKey); result != test.expected {
+				t.Errorf("expected custom acronym result %s, got %s", test.expected, result)
+			}
+		})
+	}
+}
+
+func TestCustomAcronymsToLowerCamel(t *testing.T) {
+	tests := []struct {
+		name         string
+		acronymKey   string
+		acronymValue string
+		expected     string
+	}{
+		{
+			name:         "API Custom Acronym",
+			acronymKey:   "API",
+			acronymValue: "api",
+			expected:     "api",
+		},
+		{
+			name:         "ABCDACME Custom Acroynm",
+			acronymKey:   "ABCDACME",
+			acronymValue: "AbcdAcme",
+			expected:     "abcdAcme",
+		},
+		{
+			name:         "PostgreSQL Custom Acronym",
+			acronymKey:   "PostgreSQL",
+			acronymValue: "PostgreSQL",
+			expected:     "postgreSQL",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ConfigureAcronym(test.acronymKey, test.acronymValue)
+			if result := ToLowerCamel(test.acronymKey); result != test.expected {
+				t.Errorf("expected custom acronym result %s, got %s", test.expected, result)
+			}
+		})
+	}
+}
+
 func BenchmarkToLowerCamel(b *testing.B) {
 	benchmarkCamelTest(b, toLowerCamel)
 }


### PR DESCRIPTION
I was using `strcase` to normalise some JSON  keys and found that I had an acronym which wasn't being handled nicely. The acronym was "COGS" and it was being used to convert to either Cogs or cOGS. I wanted cogs. 

With this PR I can now do

```go
strcase.ConfigureAcronym("COGS", "cogs") 
```
this now means that using `ToLowerCamel("COGS")` will give me what I need.

I think this is a useful feature in general as I found that the acronyms were currently limited to "ID": "id" with no way to configure additional ones.

Let me know if you would like to include this :)