### PR TITLE
ignore multiple chars in snake_case

### DIFF
--- a/snake.go
+++ b/snake.go
@@ -34,13 +34,13 @@ func ToSnake(s string) string {
 	return ToDelimited(s, '_')
 }
 
-func ToSnakeWithIgnore(s string, ignore uint8) string {
+func ToSnakeWithIgnore(s string, ignore string) string {
 	return ToScreamingDelimited(s, '_', ignore, false)
 }
 
 // ToScreamingSnake converts a string to SCREAMING_SNAKE_CASE
 func ToScreamingSnake(s string) string {
-	return ToScreamingDelimited(s, '_', 0, true)
+	return ToScreamingDelimited(s, '_', "", true)
 }
 
 // ToKebab converts a string to kebab-case
@@ -50,20 +50,20 @@ func ToKebab(s string) string {
 
 // ToScreamingKebab converts a string to SCREAMING-KEBAB-CASE
 func ToScreamingKebab(s string) string {
-	return ToScreamingDelimited(s, '-', 0, true)
+	return ToScreamingDelimited(s, '-', "", true)
 }
 
 // ToDelimited converts a string to delimited.snake.case
 // (in this case `delimiter = '.'`)
 func ToDelimited(s string, delimiter uint8) string {
-	return ToScreamingDelimited(s, delimiter, 0, false)
+	return ToScreamingDelimited(s, delimiter, "", false)
 }
 
 // ToScreamingDelimited converts a string to SCREAMING.DELIMITED.SNAKE.CASE
 // (in this case `delimiter = '.'; screaming = true`)
 // or delimited.snake.case
 // (in this case `delimiter = '.'; screaming = false`)
-func ToScreamingDelimited(s string, delimiter uint8, ignore uint8, screaming bool) string {
+func ToScreamingDelimited(s string, delimiter uint8, ignore string, screaming bool) string {
 	s = strings.TrimSpace(s)
 	n := strings.Builder{}
 	n.Grow(len(s) + 2) // nominal 2 bytes of extra space for inserted delimiters
@@ -87,7 +87,8 @@ func ToScreamingDelimited(s string, delimiter uint8, ignore uint8, screaming boo
 			nextIsNum := next >= '0' && next <= '9'
 			// add underscore if next letter case type is changed
 			if (vIsCap && (nextIsLow || nextIsNum)) || (vIsLow && (nextIsCap || nextIsNum)) || (vIsNum && (nextIsCap || nextIsLow)) {
-				if prevIgnore := ignore > 0 && i > 0 && s[i-1] == ignore; !prevIgnore {
+				prevIgnore := ignore != "" && i > 0 && strings.ContainsAny(string(s[i-1]), ignore)
+				if !prevIgnore {
 					if vIsCap && nextIsLow {
 						if prevIsCap := i > 0 && s[i-1] >= 'A' && s[i-1] <= 'Z'; prevIsCap {
 							n.WriteByte(delimiter)
@@ -102,8 +103,8 @@ func ToScreamingDelimited(s string, delimiter uint8, ignore uint8, screaming boo
 			}
 		}
 
-		if (v == ' ' || v == '_' || v == '-') && uint8(v) != ignore {
-			// replace space/underscore/hyphen with delimiter
+		if (v == ' ' || v == '_' || v == '-' || v == '.') && !strings.ContainsAny(string(v), ignore) {
+			// replace space/underscore/hyphen/dot with delimiter
 			n.WriteByte(delimiter)
 		} else {
 			n.WriteByte(v)

--- a/snake_test.go
+++ b/snake_test.go
@@ -92,14 +92,16 @@ func toSnakeWithIgnore(tb testing.TB) {
 		{"JSONData", "json_data"},
 		{"AwesomeActivity.UserID", "awesome_activity.user_id", "."},
 		{"AwesomeActivity.User.Id", "awesome_activity.user.id", "."},
-		{"AwesomeUsername@Awesome.Com", "awesome_username@awesome.com", "@"},
+		{"AwesomeUsername@Awesome.Com", "awesome_username@awesome.com", ".@"},
+		{"lets-ignore all.of dots-and-dashes", "lets-ignore_all.of_dots-and-dashes", ".-"},
 	}
 	for _, i := range cases {
 		in := i[0]
 		out := i[1]
-		var ignore uint8
+		var ignore string
+		ignore = ""
 		if len(i) == 3 {
-			ignore = i[2][0]
+			ignore = i[2]
 		}
 		result := ToSnakeWithIgnore(in, ignore)
 		if result != out {
@@ -222,7 +224,7 @@ func toScreamingDelimited(tb testing.TB) {
 	for _, i := range cases {
 		in := i[0]
 		out := i[1]
-		result := ToScreamingDelimited(in, '.', 0, true)
+		result := ToScreamingDelimited(in, '.', "", true)
 		if result != out {
 			tb.Errorf("%q (%q != %q)", in, result, out)
 		}
@@ -244,7 +246,7 @@ func toScreamingDelimitedWithIgnore(tb testing.TB) {
 		out := i[1]
 		delimiter := i[2][0]
 		ignore := i[3][0]
-		result := ToScreamingDelimited(in, delimiter, ignore, true)
+		result := ToScreamingDelimited(in, delimiter, string(ignore), true)
 		if result != out {
 			istr := ""
 			if len(i) == 4 {


### PR DESCRIPTION
Issues related to skipping periods in snake case are resolved. Now multiple chars may be replaced with delimiter in `ToScreamingDelimited` function. `ignore` parameter type changed to string to support a set of chars in input.
Also i had to change one of test cases.