### PR TITLE
Improve uppercase string to camel case conversion

### DIFF
--- a/camel.go
+++ b/camel.go
@@ -35,13 +35,15 @@ func toCamelInitCase(s string, initCase bool) string {
 	if s == "" {
 		return s
 	}
-	if a, ok := uppercaseAcronym[s]; ok {
+	a, hasAcronym := uppercaseAcronym[s]
+	if hasAcronym {
 		s = a
 	}
 
 	n := strings.Builder{}
 	n.Grow(len(s))
 	capNext := initCase
+	prevIsCap := false
 	for i, v := range []byte(s) {
 		vIsCap := v >= 'A' && v <= 'Z'
 		vIsLow := v >= 'a' && v <= 'z'
@@ -55,7 +57,12 @@ func toCamelInitCase(s string, initCase bool) string {
 				v += 'a'
 				v -= 'A'
 			}
+		} else if prevIsCap && vIsCap && !hasAcronym {
+			v += 'a'
+			v -= 'A'
 		}
+		prevIsCap = vIsCap
+
 		if vIsCap || vIsLow {
 			n.WriteByte(v)
 			capNext = false

--- a/camel_test.go
+++ b/camel_test.go
@@ -41,6 +41,7 @@ func toCamel(tb testing.TB) {
 		{"odd-fix", "OddFix"},
 		{"numbers2And55with000", "Numbers2And55With000"},
 		{"ID", "Id"},
+		{"CONSTANT_CASE", "ConstantCase"},
 	}
 	for _, i := range cases {
 		in := i[0]
@@ -70,6 +71,7 @@ func toLowerCamel(tb testing.TB) {
 		{"ID", "id"},
 		{"some string", "someString"},
 		{" some string", "someString"},
+		{"CONSTANT_CASE", "constantCase"},
 	}
 	for _, i := range cases {
 		in := i[0]


### PR DESCRIPTION
Fixes https://github.com/iancoleman/strcase/issues/12

Old behaviour:
`ToCamel("CONSTANT_CASE")` => `CONSTANTCASE`
`ToLowerCamel("CONSTANT_CASE")` => `cONSTANTCASE`

New behaviour:
`ToCamel("CONSTANT_CASE")`  => `ConstantCase`
`ToLowerCamel("CONSTANT_CASE")` => `constantCase`