### PR TITLE
Add optional custom acronym maps where used.

### DIFF
--- a/camel.go
+++ b/camel.go
@@ -30,12 +30,17 @@ import (
 )
 
 // Converts a string to CamelCase
-func toCamelInitCase(s string, initCase bool) string {
+func toCamelInitCase(s string, initCase bool, acronyms ...map[string]string) string {
 	s = strings.TrimSpace(s)
 	if s == "" {
 		return s
 	}
-	if a, ok := uppercaseAcronym[s]; ok {
+
+	ucAcronyms := uppercaseAcronym
+	if len(acronyms) > 0 {
+		ucAcronyms = acronyms[0]
+	}
+	if a, ok := ucAcronyms[s]; ok {
 		s = a
 	}
 
@@ -69,12 +74,14 @@ func toCamelInitCase(s string, initCase bool) string {
 	return n.String()
 }
 
-// ToCamel converts a string to CamelCase
-func ToCamel(s string) string {
-	return toCamelInitCase(s, true)
+// ToCamel converts a string to CamelCase.  It takes an optional map of acronyms
+// to use in place of the global ConfigureAcronym().
+func ToCamel(s string, acronyms ...map[string]string) string {
+	return toCamelInitCase(s, true, acronyms...)
 }
 
-// ToLowerCamel converts a string to lowerCamelCase
-func ToLowerCamel(s string) string {
-	return toCamelInitCase(s, false)
+// ToLowerCamel converts a string to lowerCamelCase.  It takes an optional map of
+// acronyms to use in place of the global ConfigureAcronym().
+func ToLowerCamel(s string, acronyms ...map[string]string) string {
+	return toCamelInitCase(s, false, acronyms...)
 }

--- a/camel_test.go
+++ b/camel_test.go
@@ -157,6 +157,52 @@ func TestCustomAcronymsToLowerCamel(t *testing.T) {
 	}
 }
 
+func TestToCamelWithAcronyms(t *testing.T) {
+	tests := []struct {
+		name       string
+		acronymKey string
+		acronymMap map[string]string
+		expected   string
+	}{
+		{
+			name:       "API Custom Acronym",
+			acronymKey: "API",
+			acronymMap: map[string]string{
+				"API": "api",
+			},
+			expected: "Api",
+		},
+		{
+			name:       "ABCDACME Custom Acroynm",
+			acronymKey: "ABCDACME",
+			acronymMap: map[string]string{
+				"ABCDACME": "AbcdAcme",
+			},
+			expected: "AbcdAcme",
+		},
+		{
+			name:       "PostgreSQL Custom Acronym",
+			acronymKey: "PostgreSQL",
+			acronymMap: map[string]string{
+				"PostgreSQL": "PostgreSQL",
+			},
+			expected: "PostgreSQL",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Set the package values to be known, bogus values to validate the
+			// map sent in is used.
+			ConfigureAcronym("API", "aPi")
+			ConfigureAcronym("ABCDACME", "AbCdAcMe")
+			ConfigureAcronym("PostgreSQL", "PoSTGreSQL")
+			if result := ToCamel(test.acronymKey, test.acronymMap); result != test.expected {
+				t.Errorf("expected custom acronym result %s, got %s", test.expected, result)
+			}
+		})
+	}
+}
+
 func BenchmarkToLowerCamel(b *testing.B) {
 	benchmarkCamelTest(b, toLowerCamel)
 }


### PR DESCRIPTION
Add an optional acronym map to ToCamel() and ToLowerCamel() that allows users to customize the specific calls to these functions while not being bound to a single global instance of the mapping.

This allows for more complex use cases where the conversions may conflict or the access to the map may introduce a race condition, while preserving the existing API.