### PR TITLE
Add new funcs allowing for non-global acronym maps.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ go:
   - 1.13.x
   - 1.14.x
   - 1.15.x
-  - master
+  - stable

--- a/camel.go
+++ b/camel.go
@@ -30,12 +30,13 @@ import (
 )
 
 // Converts a string to CamelCase
-func toCamelInitCase(s string, initCase bool) string {
+func toCamelInitCase(s string, initCase bool, acronyms map[string]string) string {
 	s = strings.TrimSpace(s)
 	if s == "" {
 		return s
 	}
-	if a, ok := uppercaseAcronym[s]; ok {
+
+	if a, ok := acronyms[s]; ok {
 		s = a
 	}
 
@@ -71,10 +72,22 @@ func toCamelInitCase(s string, initCase bool) string {
 
 // ToCamel converts a string to CamelCase
 func ToCamel(s string) string {
-	return toCamelInitCase(s, true)
+	return toCamelInitCase(s, true, uppercaseAcronym)
 }
 
 // ToLowerCamel converts a string to lowerCamelCase
 func ToLowerCamel(s string) string {
-	return toCamelInitCase(s, false)
+	return toCamelInitCase(s, false, uppercaseAcronym)
+}
+
+// ToCamelWithAcronyms converts a string to CamelCase using custom specified
+// acronyms.
+func ToCamelWithAcronyms(s string, acronyms map[string]string) string {
+	return toCamelInitCase(s, true, acronyms)
+}
+
+// ToLowerCamelWithAcronyms converts a string to lowerCamelCase using custom
+// specified acronyms.
+func ToLowerCamelWithAcronyms(s string, acronyms map[string]string) string {
+	return toCamelInitCase(s, false, acronyms)
 }

--- a/camel_test.go
+++ b/camel_test.go
@@ -157,6 +157,98 @@ func TestCustomAcronymsToLowerCamel(t *testing.T) {
 	}
 }
 
+func TestToCamelWithAcronyms(t *testing.T) {
+	tests := []struct {
+		name       string
+		acronymKey string
+		acronymMap map[string]string
+		expected   string
+	}{
+		{
+			name:       "API Custom Acronym",
+			acronymKey: "API",
+			acronymMap: map[string]string{
+				"API": "api",
+			},
+			expected: "Api",
+		},
+		{
+			name:       "ABCDACME Custom Acroynm",
+			acronymKey: "ABCDACME",
+			acronymMap: map[string]string{
+				"ABCDACME": "AbcdAcme",
+			},
+			expected: "AbcdAcme",
+		},
+		{
+			name:       "PostgreSQL Custom Acronym",
+			acronymKey: "PostgreSQL",
+			acronymMap: map[string]string{
+				"PostgreSQL": "PostgreSQL",
+			},
+			expected: "PostgreSQL",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Set the package values to be known, bogus values to validate the
+			// map sent in is used.
+			ConfigureAcronym("API", "aPi")
+			ConfigureAcronym("ABCDACME", "AbCdAcMe")
+			ConfigureAcronym("PostgreSQL", "PoSTGreSQL")
+			if result := ToCamelWithAcronyms(test.acronymKey, test.acronymMap); result != test.expected {
+				t.Errorf("expected custom acronym result %s, got %s", test.expected, result)
+			}
+		})
+	}
+}
+
+func TestToLowerCamelWithAcronyms(t *testing.T) {
+	tests := []struct {
+		name       string
+		acronymKey string
+		acronymMap map[string]string
+		expected   string
+	}{
+		{
+			name:       "API Custom Acronym",
+			acronymKey: "API",
+			acronymMap: map[string]string{
+				"API": "api",
+			},
+			expected: "api",
+		},
+		{
+			name:       "ABCDACME Custom Acroynm",
+			acronymKey: "ABCDACME",
+			acronymMap: map[string]string{
+				"ABCDACME": "AbcdAcme",
+			},
+			expected: "abcdAcme",
+		},
+		{
+			name:       "PostgreSQL Custom Acronym",
+			acronymKey: "PostgreSQL",
+			acronymMap: map[string]string{
+				"PostgreSQL": "PostgreSQL",
+			},
+			expected: "postgreSQL",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Set the package values to be known, bogus values to validate the
+			// map sent in is used.
+			ConfigureAcronym("API", "aPi")
+			ConfigureAcronym("ABCDACME", "AbCdAcMe")
+			ConfigureAcronym("PostgreSQL", "PoSTGreSQL")
+			if result := ToLowerCamelWithAcronyms(test.acronymKey, test.acronymMap); result != test.expected {
+				t.Errorf("expected custom acronym result %s, got %s", test.expected, result)
+			}
+		})
+	}
+}
+
 func BenchmarkToLowerCamel(b *testing.B) {
 	benchmarkCamelTest(b, toLowerCamel)
 }


### PR DESCRIPTION
Add two new functions ToCamelWithAcronyms() and
ToLowerCamelWithAcronyms() that take a map[string]string of acronyms to use in place of the globally referenced value.

This allows for more complex use cases where the conversions may conflict or the access to the map may introduce a race condition, while preserving the existing API.