### PR TITLE
Changing `ToCamel` to `ToPascal` and `ToLowerCamel` to `ToCamel` for better readability 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ s := "AnyKind of_string"
 | `ToDelimited(s, '.')`                     | `any.kind.of.string` |
 | `ToScreamingDelimited(s, '.', '', true)`  | `ANY.KIND.OF.STRING` |
 | `ToScreamingDelimited(s, '.', ' ', true)` | `ANY.KIND OF.STRING` |
-| `ToCamel(s)`                              | `AnyKindOfString`    |
-| `ToLowerCamel(s)`                         | `anyKindOfString`    |
+| `ToPascal(s)`                             | `AnyKindOfString`    |
+| `ToCamel(s)`                              | `anyKindOfString`    |
 
 
 ## Install

--- a/camel.go
+++ b/camel.go
@@ -71,10 +71,10 @@ func toCamelInitCase(s string, initCase bool) string {
 
 // ToCamel converts a string to CamelCase
 func ToCamel(s string) string {
-	return toCamelInitCase(s, true)
+	return toCamelInitCase(s, false)
 }
 
-// ToLowerCamel converts a string to lowerCamelCase
-func ToLowerCamel(s string) string {
-	return toCamelInitCase(s, false)
+// ToCamel converts a string to PasCalCase
+func ToPascal(s string) string {
+	return toCamelInitCase(s, true)
 }

--- a/camel_test.go
+++ b/camel_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 )
 
-func toCamel(tb testing.TB) {
+func toPascal(tb testing.TB) {
 	cases := [][]string{
 		{"test_case", "TestCase"},
 		{"test.case", "TestCase"},
@@ -45,22 +45,22 @@ func toCamel(tb testing.TB) {
 	for _, i := range cases {
 		in := i[0]
 		out := i[1]
-		result := ToCamel(in)
+		result := ToPascal(in)
 		if result != out {
 			tb.Errorf("%q (%q != %q)", in, result, out)
 		}
 	}
 }
 
-func TestToCamel(t *testing.T) {
-	toCamel(t)
+func TestToPascal(t *testing.T) {
+	toPascal(t)
 }
 
-func BenchmarkToCamel(b *testing.B) {
-	benchmarkCamelTest(b, toCamel)
+func BenchmarkToPascal(b *testing.B) {
+	benchmarkCamelTest(b, toPascal)
 }
 
-func toLowerCamel(tb testing.TB) {
+func toCamel(tb testing.TB) {
 	cases := [][]string{
 		{"foo-bar", "fooBar"},
 		{"TestCase", "testCase"},
@@ -74,18 +74,18 @@ func toLowerCamel(tb testing.TB) {
 	for _, i := range cases {
 		in := i[0]
 		out := i[1]
-		result := ToLowerCamel(in)
+		result := ToCamel(in)
 		if result != out {
 			tb.Errorf("%q (%q != %q)", in, result, out)
 		}
 	}
 }
 
-func TestToLowerCamel(t *testing.T) {
-	toLowerCamel(t)
+func TestToCamel(t *testing.T) {
+	toCamel(t)
 }
 
-func TestCustomAcronymsToCamel(t *testing.T) {
+func TestCustomAcronymsToPascal(t *testing.T) {
 	tests := []struct {
 		name         string
 		acronymKey   string
@@ -114,14 +114,14 @@ func TestCustomAcronymsToCamel(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ConfigureAcronym(test.acronymKey, test.acronymValue)
-			if result := ToCamel(test.acronymKey); result != test.expected {
+			if result := ToPascal(test.acronymKey); result != test.expected {
 				t.Errorf("expected custom acronym result %s, got %s", test.expected, result)
 			}
 		})
 	}
 }
 
-func TestCustomAcronymsToLowerCamel(t *testing.T) {
+func TestCustomAcronymsToCamel(t *testing.T) {
 	tests := []struct {
 		name         string
 		acronymKey   string
@@ -150,15 +150,15 @@ func TestCustomAcronymsToLowerCamel(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ConfigureAcronym(test.acronymKey, test.acronymValue)
-			if result := ToLowerCamel(test.acronymKey); result != test.expected {
+			if result := ToCamel(test.acronymKey); result != test.expected {
 				t.Errorf("expected custom acronym result %s, got %s", test.expected, result)
 			}
 		})
 	}
 }
 
-func BenchmarkToLowerCamel(b *testing.B) {
-	benchmarkCamelTest(b, toLowerCamel)
+func BenchmarkToCamel(b *testing.B) {
+	benchmarkCamelTest(b, toCamel)
 }
 
 func benchmarkCamelTest(b *testing.B, fn func(testing.TB)) {


### PR DESCRIPTION
I changed`ToCamel` to `ToPascal` and `ToLowerCamel` to `ToCamel` for better readability, because I think these terms make more sense (and are better understood by the majority of people). 