### PR TITLE
Use ASCIISet to lower execution time by ~10 to 30%

### DIFF
--- a/chars.go
+++ b/chars.go
@@ -25,56 +25,9 @@
 
 package strcase
 
-import (
-	"strings"
-)
+import asciiset "github.com/elliotwutingfeng/asciiset"
 
-// Converts a string to CamelCase
-func toCamelInitCase(s string, initCase bool) string {
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return s
-	}
-	if a, ok := uppercaseAcronym[s]; ok {
-		s = a
-	}
-
-	n := strings.Builder{}
-	n.Grow(len(s))
-	capNext := initCase
-	for i, v := range []byte(s) {
-		vIsCap := capitalLetters.Contains(v)
-		vIsLow := smallLetters.Contains(v)
-		if capNext {
-			if vIsLow {
-				v += 'A'
-				v -= 'a'
-			}
-		} else if i == 0 {
-			if vIsCap {
-				v += 'a'
-				v -= 'A'
-			}
-		}
-		if vIsCap || vIsLow {
-			n.WriteByte(v)
-			capNext = false
-		} else if vIsNum := numbers.Contains(v); vIsNum {
-			n.WriteByte(v)
-			capNext = true
-		} else {
-			capNext = separators.Contains(v)
-		}
-	}
-	return n.String()
-}
-
-// ToCamel converts a string to CamelCase
-func ToCamel(s string) string {
-	return toCamelInitCase(s, true)
-}
-
-// ToLowerCamel converts a string to lowerCamelCase
-func ToLowerCamel(s string) string {
-	return toCamelInitCase(s, false)
-}
+var numbers, _ = asciiset.MakeASCIISet("0123456789")
+var smallLetters, _ = asciiset.MakeASCIISet("abcdefghijklmnopqrstuvwxyz")
+var capitalLetters, _ = asciiset.MakeASCIISet("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+var separators, _ = asciiset.MakeASCIISet(" _-.")

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/iancoleman/strcase
 
 go 1.16
+
+require github.com/elliotwutingfeng/asciiset v0.0.0-20230318033524-4982e1c19ba9

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/elliotwutingfeng/asciiset v0.0.0-20230318033524-4982e1c19ba9 h1:FFVdM8Ai0s6G5W5ltfXGV/3nINtnUe9590OjdwKamuA=
+github.com/elliotwutingfeng/asciiset v0.0.0-20230318033524-4982e1c19ba9/go.mod h1:GLo/8fDswSAniFG+BFIaiSPcK610jyzgEhWYPQwuQdw=


### PR DESCRIPTION
## Changes

- Use ASCIISet, a zero dependency and zero heap allocation module for checking byte values, to reduce execution time by **~10 to 30%** (see benchmarks below)


## Benchmarks

### Command

```bash
go test -bench . -benchmem -cpu 1
```

### Before

```
goos: linux
goarch: amd64
pkg: github.com/iancoleman/strcase
cpu: AMD Ryzen 7 5800X 8-Core Processor             
BenchmarkToCamel                                 2112366               575.0 ns/op           128 B/op         10 allocs/op
BenchmarkToLowerCamel                            2861402               409.6 ns/op            96 B/op          7 allocs/op
BenchmarkToSnake                                  621049              1894 ns/op             480 B/op         30 allocs/op
BenchmarkToSnakeWithIgnore                        565810              2040 ns/op             408 B/op         20 allocs/op
BenchmarkToDelimited                              850269              1374 ns/op             304 B/op         19 allocs/op
BenchmarkToScreamingSnake                       20631154                59.00 ns/op           16 B/op          1 allocs/op
BenchmarkToKebab                                19712632                60.27 ns/op           16 B/op          1 allocs/op
BenchmarkToScreamingKebab                       20477086                58.17 ns/op           16 B/op          1 allocs/op
BenchmarkToScreamingDelimited                   20021593                58.48 ns/op           16 B/op          1 allocs/op
BenchmarkToScreamingDelimitedWithIgnore          8217859               145.8 ns/op            24 B/op          1 allocs/op
PASS
ok      github.com/iancoleman/strcase   13.300s
```

### After

```
goos: linux
goarch: amd64
pkg: github.com/iancoleman/strcase
cpu: AMD Ryzen 7 5800X 8-Core Processor             
BenchmarkToCamel                                 2503086               483.8 ns/op           128 B/op         10 allocs/op
BenchmarkToLowerCamel                            3385527               351.1 ns/op            96 B/op          7 allocs/op
BenchmarkToSnake                                  708350              1663 ns/op             480 B/op         30 allocs/op
BenchmarkToSnakeWithIgnore                        676756              1627 ns/op             408 B/op         20 allocs/op
BenchmarkToDelimited                              908474              1136 ns/op             304 B/op         19 allocs/op
BenchmarkToScreamingSnake                       21560983                55.12 ns/op           16 B/op          1 allocs/op
BenchmarkToKebab                                22520330                52.71 ns/op           16 B/op          1 allocs/op
BenchmarkToScreamingKebab                       22808118                51.95 ns/op           16 B/op          1 allocs/op
BenchmarkToScreamingDelimited                   21881048                51.62 ns/op           16 B/op          1 allocs/op
BenchmarkToScreamingDelimitedWithIgnore         11011074               105.1 ns/op            24 B/op          1 allocs/op
PASS
ok      github.com/iancoleman/strcase   12.786s
```