### PR TITLE
Camel behaviour change

### DIFF
--- a/camel_test.go
+++ b/camel_test.go
@@ -40,6 +40,7 @@ func toCamel(tb testing.TB) {
 		{"AnyKind of_string", "AnyKindOfString"},
 		{"odd-fix", "OddFix"},
 		{"numbers2And55with000", "Numbers2And55With000"},
+		{"DBClusterParameterGroup", "DBClusterParameterGroup"},
 		{"ID", "Id"},
 	}
 	for _, i := range cases {
@@ -70,6 +71,7 @@ func toLowerCamel(tb testing.TB) {
 		{"ID", "id"},
 		{"some string", "someString"},
 		{" some string", "someString"},
+		{"DBClusterParameterGroup", "dBClusterParameterGroup"},
 	}
 	for _, i := range cases {
 		in := i[0]


### PR DESCRIPTION
Hi,

this PR is to show the behaviour change of ToCamel/ToLowerCamel as of 0.3.0. The testcase in 262f4c7eed578300626d2acf41c12f45772eb35d passes for 0.2.0 but fails with 0.3.0.